### PR TITLE
Workaround for date parsing error

### DIFF
--- a/api/event.py
+++ b/api/event.py
@@ -1,4 +1,5 @@
 from datetime import datetime, date
+import time
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.000Z'
 
@@ -7,8 +8,14 @@ class Event(object):
     self.display_name = json['display_name']
     self.short_code = json['short_code']
     self.conference = json['conference']
-    self.start_at = datetime.strptime(json['start_at'], DATETIME_FORMAT)
-    self.end_at = datetime.strptime(json['end_at'], DATETIME_FORMAT)
+    self.start_at = self.parse_date(json['start_at'])
+    self.end_at = self.parse_date(json['end_at'])
+
+  def parse_date(self, date_string):
+    try:
+      return datetime.strptime(date_string, DATETIME_FORMAT)
+    except TypeError:
+      return datetime(*(time.strptime(date_string, DATETIME_FORMAT)[0:6]))
 
   # Format start date e.g. 'Jan 10'
   def pretty_start(self):


### PR DESCRIPTION
I was getting an error at startup

```
NOTICE: [xbmcswift2] Request for "/" matches rule for function "index"
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
   - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
  Error Type: <type 'exceptions.TypeError'>
  Error Contents: attribute of type 'NoneType' is not callable
  Traceback (most recent call last):
    File "/home/tibi/.kodi/addons/plugin.video.confreaks/addon.py", line 31, in <module>
      plugin.run()
    File "/home/tibi/.kodi/addons/script.module.xbmcswift2/lib/xbmcswift2/plugin.py", line 332, in run
      items = self._dispatch(self.request.path)
    File "/home/tibi/.kodi/addons/script.module.xbmcswift2/lib/xbmcswift2/plugin.py", line 306, in _dispatch
      listitems = view_func(**items)
    File "/home/tibi/.kodi/addons/plugin.video.confreaks/addon.py", line 18, in index
      } for event in Router.events()]
    File "/home/tibi/.kodi/addons/plugin.video.confreaks/api/router.py", line 11, in events
      return [Event(event) for event in json.load(response)]
    File "/home/tibi/.kodi/addons/plugin.video.confreaks/api/event.py", line 10, in __init__
      self.start_at = datetime.strptime(json['start_at'], DATETIME_FORMAT)
  TypeError: attribute of type 'NoneType' is not callable
```

It's thrown by this line,
`datetime.strptime(json['start_at'], DATETIME_FORMAT)`

Not sure why it happens but found a workaround in this thread
http://forum.kodi.tv/showthread.php?tid=112916&pid=1214507#pid1214507
